### PR TITLE
Enable mirrored strategy on CPUs and fix metrics

### DIFF
--- a/mlpf/pipeline.py
+++ b/mlpf/pipeline.py
@@ -116,7 +116,8 @@ def main():
 @click.option("-b", "--benchmark_dir", help="dir to save becnhmark results", type=str, default=None)
 @click.option("-B", "--batch_size", help="batch size per device", type=int, default=None)
 @click.option("-D", "--num_devices", help="number of devices to use", type=int, default=0)
-def train(config, weights, ntrain, ntest, nepochs, recreate, prefix, plot_freq, customize, benchmark_dir, batch_size, num_devices):
+@click.option("-s", "--seeds", help="set the random seeds", is_flag=True, default=True)
+def train(config, weights, ntrain, ntest, nepochs, recreate, prefix, plot_freq, customize, benchmark_dir, batch_size, num_devices, seeds):
 
     try:
         from comet_ml import Experiment
@@ -132,6 +133,10 @@ def train(config, weights, ntrain, ntest, nepochs, recreate, prefix, plot_freq, 
         print("Failed to initialize comet-ml dashboard")
         experiment = None
 
+    if seeds:
+        random.seed(1234)
+        np.random.seed(1234)
+        tf.random.set_seed(1234)
 
     """Train a model defined by config"""
     config_file_path = config
@@ -258,6 +263,7 @@ def train(config, weights, ntrain, ntest, nepochs, recreate, prefix, plot_freq, 
                 batch_size_per_gpu=config["train_test_datasets"]["delphes"]["batch_per_gpu"],
                 num_gpus=num_gpus,
                 num_devices=num_devices,
+                train_set_size=len(ds_train),
             )
         )
 

--- a/mlpf/pipeline.py
+++ b/mlpf/pipeline.py
@@ -100,7 +100,7 @@ customization_functions = {
 @click.help_option("-h", "--help")
 def main():
     pass
-        
+
 
 @main.command()
 @click.help_option("-h", "--help")
@@ -114,7 +114,9 @@ def main():
 @click.option("--plot-freq", default=None, help="plot detailed validation every N epochs", type=int)
 @click.option("--customize", help="customization function", type=str, default=None)
 @click.option("-b", "--benchmark_dir", help="dir to save becnhmark results", type=str, default=None)
-def train(config, weights, ntrain, ntest, nepochs, recreate, prefix, plot_freq, customize, benchmark_dir):
+@click.option("-B", "--batch_size", help="batch size per device", type=int, default=None)
+@click.option("-D", "--num_devices", help="number of devices to use", type=int, default=0)
+def train(config, weights, ntrain, ntest, nepochs, recreate, prefix, plot_freq, customize, benchmark_dir, batch_size, num_devices):
 
     try:
         from comet_ml import Experiment
@@ -140,6 +142,9 @@ def train(config, weights, ntrain, ntest, nepochs, recreate, prefix, plot_freq, 
     if plot_freq:
         config["callbacks"]["plot_freq"] = plot_freq
 
+    if batch_size:
+        config["train_test_datasets"]["delphes"]["batch_per_gpu"] = batch_size
+
     if customize:
         config = customization_functions[customize](config)
 
@@ -149,14 +154,16 @@ def train(config, weights, ntrain, ntest, nepochs, recreate, prefix, plot_freq, 
         outdir = str(Path(weights).parent)
 
     # Decide tf.distribute.strategy depending on number of available GPUs
-    strategy, num_gpus = get_strategy()
+    strategy, num_gpus = get_strategy(num_devices=num_devices)
+    devices = num_gpus or num_devices
+
     #if "CPU" not in strategy.extended.worker_devices[0]:
     #    nvidia_smi_call = "nvidia-smi --query-gpu=timestamp,name,pci.bus_id,pstate,power.draw,temperature.gpu,utilization.gpu,utilization.memory,memory.total,memory.free,memory.used --format=csv -l 1 -f {}/nvidia_smi_log.csv".format(outdir)
     #    p = subprocess.Popen(shlex.split(nvidia_smi_call))
 
-    ds_train, num_train_steps = get_datasets(config["train_test_datasets"], config, num_gpus, "train")
-    ds_test, num_test_steps = get_datasets(config["train_test_datasets"], config, num_gpus, "test")
-    ds_val, ds_info = get_heptfds_dataset(config["validation_dataset"], config, num_gpus, "test", config["setup"]["num_events_validation"])
+    ds_train, num_train_steps = get_datasets(config["train_test_datasets"], config, devices, "train")
+    ds_test, num_test_steps = get_datasets(config["train_test_datasets"], config, devices, "test")
+    ds_val, ds_info = get_heptfds_dataset(config["validation_dataset"], config, devices, "test", config["setup"]["num_events_validation"])
     ds_val = ds_val.batch(5)
 
     if ntrain:
@@ -250,8 +257,9 @@ def train(config, weights, ntrain, ntest, nepochs, recreate, prefix, plot_freq, 
                 steps_per_epoch=num_train_steps,
                 batch_size_per_gpu=config["train_test_datasets"]["delphes"]["batch_per_gpu"],
                 num_gpus=num_gpus,
-                )
+                num_devices=num_devices,
             )
+        )
 
     fit_result = model.fit(
         ds_train.repeat(),
@@ -323,7 +331,7 @@ def evaluate(config, train_dir, weights, evaluation_dir):
         weights = get_best_checkpoint(train_dir)
         print("Loading best weights that could be found from {}".format(weights))
         model.load_weights(weights, by_name=True)
-    
+
     eval_model(model, ds_test, config, eval_dir)
     freeze_model(model, config, ds_test.take(1), train_dir)
 
@@ -416,7 +424,7 @@ def hypertune(config, outdir, ntrain, ntest, recreate):
         config["setup"]["num_epochs"] = config["hypertune"]["hyperband"]["max_epochs"]
 
     strategy, num_gpus = get_strategy()
- 
+
     ds_train, ds_info = get_heptfds_dataset(config["training_dataset"], config, num_gpus, "train", config["setup"]["num_events_train"])
     ds_test, _ = get_heptfds_dataset(config["testing_dataset"], config, num_gpus, "test", config["setup"]["num_events_test"])
     ds_val, _ = get_heptfds_dataset(config["validation_dataset"], config, num_gpus, "test", config["setup"]["num_events_validation"])

--- a/mlpf/tfmodel/callbacks.py
+++ b/mlpf/tfmodel/callbacks.py
@@ -169,7 +169,7 @@ class BenchmarkLogggerCallback(tf.keras.callbacks.Callback):
                 "train_stop": stop_time,
                 "train_time": total_time,
                 "GPU": self.num_gpus,
-                "CPU": 0 if self.num_gpu else self.num_devices,
+                "CPU": 0 if self.num_gpus else self.num_devices,
                 "batch_size_per_device": self.batch_size_per_gpu,
                 "batch_total_size": self.batch_size_per_gpu * self.num_devices,
                 "steps_per_epoch": self.steps_per_epoch,

--- a/mlpf/tfmodel/utils.py
+++ b/mlpf/tfmodel/utils.py
@@ -102,12 +102,18 @@ def get_strategy(num_devices=0):
     else:
         num_gpus = len(gpus)
     print("num_gpus=", num_gpus)
-    if num_gpus > 1 or num_devices > 0:
+
+    if num_gpus > 1:
+        # multiple GPUs selected
+        strategy = tf.distribute.MirroredStrategy(["gpu:{}".format(g) for g in gpus])
+    elif num_devices > 1:
+        # CPU parallelization
         strategy = tf.distribute.MirroredStrategy()
     elif num_gpus == 1:
+        # single GPU
         strategy = tf.distribute.OneDeviceStrategy("gpu:{}".format(gpus[0]))
-    elif num_gpus == 0:
-        print("fallback to CPU")
+    else:
+        print("Fallback to CPU")
         strategy = tf.distribute.OneDeviceStrategy("cpu")
 
     return strategy, num_gpus

--- a/mlpf/tfmodel/utils.py
+++ b/mlpf/tfmodel/utils.py
@@ -90,7 +90,7 @@ def delete_all_but_best_checkpoint(train_dir, dry_run):
         print("Removed all checkpoints in {} except {}".format(train_dir, best_ckpt))
 
 
-def get_strategy(num_devices=0):
+def get_strategy(num_devices=1):
     if isinstance(os.environ.get("CUDA_VISIBLE_DEVICES"), type(None)) or len(os.environ.get("CUDA_VISIBLE_DEVICES")) == 0:
         gpus = [-1]
         print("WARNING: CUDA_VISIBLE_DEVICES variable is empty. \
@@ -378,12 +378,10 @@ def get_heptfds_dataset(dataset_name, config, num_gpus, split, num_events=None):
         raise ValueError("Only supported datasets are 'cms' and 'delphes'.")
 
     ds, ds_info = dsf.get_dataset(dataset_name, config["datasets"][dataset_name], split)
-    #bs = config["datasets"][dataset_name]["batch_per_gpu"]
 
     if not (num_events is None):
         ds = ds.take(num_events)
 
-    #ds = ds.batch(bs)
     ds = ds.map(dsf.get_map_to_supervised())
 
     return ds, ds_info
@@ -418,22 +416,26 @@ def load_and_interleave(dataset_names, config, num_gpus, split, batch_size):
     if num_gpus>1:
         bs = bs*num_gpus
     ds = ds.batch(bs)
-    return ds
+    return ds, len(indices)
 
 #Load multiple datasets and mix them together
 def get_datasets(datasets_to_interleave, config, num_gpus, split):
     datasets = []
     steps = []
+    num_samples = 0
     for joint_dataset_name in datasets_to_interleave.keys():
         ds_conf = datasets_to_interleave[joint_dataset_name]
         if ds_conf["datasets"] is None:
             logging.warning("No datasets in {} list.".format(joint_dataset_name))
         else:
-            interleaved_ds = load_and_interleave(ds_conf["datasets"], config, num_gpus, split, ds_conf["batch_per_gpu"])
-            num_steps = len(interleaved_ds)
+            interleaved_ds, ds_samples = load_and_interleave(ds_conf["datasets"], config, num_gpus, split, ds_conf["batch_per_gpu"])
+            num_steps = 0
+            for _ in interleaved_ds:
+                num_steps += 1
             print("Interleaved joint dataset {} with {} steps".format(joint_dataset_name, num_steps))
             datasets.append(interleaved_ds)
             steps.append(num_steps)
+            num_samples += ds_samples
 
     ids = 0
     indices = []
@@ -445,10 +447,10 @@ def get_datasets(datasets_to_interleave, config, num_gpus, split):
 
     choice_dataset = tf.data.Dataset.from_tensor_slices(indices)
     ds = tf.data.experimental.choose_from_datasets(datasets, choice_dataset)
-    num_steps = len(ds)
+    num_steps = len(indices)
 
     print("Final dataset with {} steps".format(num_steps))
-    return ds, num_steps
+    return ds, num_steps, num_samples
 
 def set_config_loss(config, trainable):
     if trainable == "classification":

--- a/mlpf/tfmodel/utils.py
+++ b/mlpf/tfmodel/utils.py
@@ -430,9 +430,7 @@ def get_datasets(datasets_to_interleave, config, num_gpus, split):
             logging.warning("No datasets in {} list.".format(joint_dataset_name))
         else:
             interleaved_ds = load_and_interleave(ds_conf["datasets"], config, num_gpus, split, ds_conf["batch_per_gpu"])
-            num_steps = 0
-            for elem in interleaved_ds:
-                num_steps += 1
+            num_steps = len(interleaved_ds)
             print("Interleaved joint dataset {} with {} steps".format(joint_dataset_name, num_steps))
             datasets.append(interleaved_ds)
             steps.append(num_steps)
@@ -447,9 +445,7 @@ def get_datasets(datasets_to_interleave, config, num_gpus, split):
 
     choice_dataset = tf.data.Dataset.from_tensor_slices(indices)
     ds = tf.data.experimental.choose_from_datasets(datasets, choice_dataset)
-    num_steps = 0
-    for elem in ds:
-        num_steps += 1
+    num_steps = len(ds)
 
     print("Final dataset with {} steps".format(num_steps))
     return ds, num_steps


### PR DESCRIPTION
Enable running Mirrored strategy on CPUs.

Running mirrored strategy on HPC grade CPUs (with many cores) seems to yield better results than OneDeviceStrategy.
Make this option configurable and support batch size adjustments.